### PR TITLE
Replace unzip package with unzipper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var through = require('through2');
 var gutil = require('gulp-util')
-var unzip = require('unzip')
+var unzip = require('unzipper')
 var fs = require('fs')
 var defaults = require('defaults')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-unzip",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "gulp plugin for unzip",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   "author": "suisho",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "unzip": "^0.1.11",
+    "defaults": "^1.0.0",
     "gulp-util": "^2.2.14",
     "through2": "^0.4.1",
-    "defaults": "^1.0.0"
+    "unzipper": "^0.7.1"
   },
   "devDependencies": {
     "mocha": "^1.18.0",


### PR DESCRIPTION
This replaces the abandoned (and buggy) [node-unzip](https://github.com/EvanOxfeld/node-unzip) with a recent and maintained fork called [unzipper](https://github.com/ZJONSSON/node-unzipper).

The fork/unzipper maintains full API compatibility with unzip and fixes to crucial bugs:

* Finish/close events are not always triggered, particular when the input stream is slower than the receivers
* Any files are buffered into memory before passing on to entry

I also only bumped the patch number, due to it being a transparent change, but am happy to change bump minor or major if required. This should fix a number of underlying issues with `gulp-unzip` such as working with large archives.

/cc @ZJONSSON